### PR TITLE
Wait for other UI actions to be done on main thread.

### DIFF
--- a/INSPullToRefresh/INSPullToRefreshBackgroundView.m
+++ b/INSPullToRefresh/INSPullToRefreshBackgroundView.m
@@ -141,7 +141,9 @@ CGFloat const INSPullToRefreshDefaultDragToTriggerOffset = 80;
     if (self.state == INSPullToRefreshBackgroundViewStateNone) {
         [self changeState:INSPullToRefreshBackgroundViewStateTriggered];
         
-        [self.scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x, -CGRectGetHeight(self.frame) -_externalContentInset.top ) animated:YES];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x, -CGRectGetHeight(self.frame) -_externalContentInset.top ) animated:YES];
+        });
         
         [self changeState:INSPullToRefreshBackgroundViewStateLoading];
     }
@@ -151,7 +153,9 @@ CGFloat const INSPullToRefreshDefaultDragToTriggerOffset = 80;
         [self changeState:INSPullToRefreshBackgroundViewStateNone];
         if (self.scrollToTopAfterEndRefreshing) {
             CGPoint originalContentOffset = CGPointMake(-_externalContentInset.left, -_externalContentInset.top);
-            [self.scrollView setContentOffset:originalContentOffset animated:NO];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.scrollView setContentOffset:originalContentOffset animated:NO];
+            });
         }
     }
 }


### PR DESCRIPTION
There may be unexpected behaviors calling `setContentOffset:animated:` when the scroll view is performing other UI actions. Submitting the `setContentOffset:animated:` action to the main queue ensures that it waits until other actions are done. 

This should fix #3.