### PR TITLE
Prevent infiniteScroll conflict

### DIFF
--- a/INSPullToRefresh/INSInfiniteScrollBackgroundView.m
+++ b/INSPullToRefresh/INSInfiniteScrollBackgroundView.m
@@ -102,7 +102,9 @@ static CGFloat const INSInfinityScrollContentInsetAnimationTime = 0.3;
 
     // The lower bound when infinite scroll should kick in
     CGFloat actionOffset = contentHeight - self.scrollView.bounds.size.height + self.scrollView.contentInset.bottom - self.additionalBottomOffsetForInfinityScrollTrigger;
-
+    // Prevent conflict with pull to refresh when tableView is too short
+    actionOffset = fmaxf(actionOffset, self.additionalBottomOffsetForInfinityScrollTrigger);
+    
     // Disable infinite scroll when scroll view is empty
     // Default UITableView reports height = 1 on empty tables
     BOOL hasActualContent = (self.scrollView.contentSize.height > 1);


### PR DESCRIPTION
Prevent infiniteScroll conflict with pull to refresh when tableView is too short.

Before:
![before](https://cloud.githubusercontent.com/assets/1998065/6917535/052a6cf0-d7d8-11e4-8a01-8a12b30ae3f1.gif)

After:
![after](https://cloud.githubusercontent.com/assets/1998065/6917601/a39d2d14-d7d8-11e4-9b5e-0b7a50b56c15.gif)


