### PR TITLE
Remove NSLog statement

### DIFF
--- a/INSPullToRefresh/INSPullToRefreshBackgroundView.m
+++ b/INSPullToRefresh/INSPullToRefreshBackgroundView.m
@@ -241,7 +241,7 @@ CGFloat const INSPullToRefreshDefaultDragToTriggerOffset = 80;
         return;
     }
     
-    NSLog(@"%@ %@",keyPath,change[@"new"]);
+    //NSLog(@"%@ %@",keyPath,change[@"new"]);
     
     if ([keyPath isEqualToString:@"contentOffset"]) {
         [self scrollViewDidScroll:[[change valueForKey:NSKeyValueChangeNewKey] CGPointValue]];


### PR DESCRIPTION
Removed because printing to console while scrolling it is affecting scrolling performance in all of my scroll views.