### PR TITLE
Fix behaviour when starting and ending refresh in the same call sequence

### DIFF
--- a/INSPullToRefresh/INSPullToRefreshBackgroundView.m
+++ b/INSPullToRefresh/INSPullToRefreshBackgroundView.m
@@ -162,7 +162,9 @@ CGFloat const INSPullToRefreshDefaultDragToTriggerOffset = 80;
         [self changeState:INSPullToRefreshBackgroundViewStateTriggered];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x, -CGRectGetHeight(self.frame) -_externalContentInset.top ) animated:YES];
+			if (self.state != INSPullToRefreshBackgroundViewStateNone) {
+				[self.scrollView setContentOffset:CGPointMake(_scrollView.contentOffset.x, -CGRectGetHeight(self.frame) -_externalContentInset.top ) animated:YES];
+			}
         });
         
         [self changeState:INSPullToRefreshBackgroundViewStateLoading];


### PR DESCRIPTION
See issue: https://github.com/inspace-io/INSPullToRefresh/issues/52