### PR TITLE
Check alreadyUpdating before setting contentInset to prevent potential infinite loop

### DIFF
--- a/INSPullToRefresh/INSPullToRefreshBackgroundView.m
+++ b/INSPullToRefresh/INSPullToRefreshBackgroundView.m
@@ -380,9 +380,7 @@ CGFloat const INSPullToRefreshDefaultDragToTriggerOffset = 80;
     BOOL alreadyUpdating = _updatingScrollViewContentInset; // Check to prevent errors from recursive calls.
     if (!alreadyUpdating) {
         self.updatingScrollViewContentInset = YES;
-    }
-    self.scrollView.contentInset = contentInset;
-    if (!alreadyUpdating) {
+        self.scrollView.contentInset = contentInset;
         self.updatingScrollViewContentInset = NO;
     }
 }


### PR DESCRIPTION
I'm using INSPullToRefresh in a `UIWebView`'s `scrollView`, when I pull the webview for refresh, it will cause infinite recursive call on `UIScrollView`'s `setContentInset:`. Turns out when `INSPullToRefreshBackgroundView` set the `contentInset` of `scrollView`, it's not really checking if it's already updating, and `UIWebView` somehow adjust the `scrollView`'s `contentInset` internally when it detected it's `contentInset` is changed, and it create an infinite loop, so I added the checking code to break the loop. 

It works, but I don't quite understand why the code was written like that before, maybe there're some pitfalls I didn't see, please review my changes.