### PR TITLE
Fixed crash on firstResponder search

### DIFF
--- a/INSPullToRefresh/UIView+INSFirstReponder.m
+++ b/INSPullToRefresh/UIView+INSFirstReponder.m
@@ -15,8 +15,12 @@
     while ([responder isKindOfClass:[UIView class]]) {
         responder = [responder nextResponder];
     }
-    
-    return (UIViewController *)responder;
+
+    if ([responder isKindOfClass:[UIViewController class]]) {
+        return (UIViewController *)responder;
+    }
+
+    return nil;
 }
 
 @end


### PR DESCRIPTION
Hello
In apps first responder is not always viewController (e.g. it could be an UIApplication object). So an explicit typecast causes problems and crashes our application. Have a look on fix