### PR TITLE
The infinite scroll action could be called immediately or with delay.

### DIFF
--- a/INSPullToRefresh/INSInfiniteScrollBackgroundView.h
+++ b/INSPullToRefresh/INSInfiniteScrollBackgroundView.h
@@ -53,6 +53,8 @@ typedef NS_ENUM(NSUInteger, INSInfiniteScrollBackgroundViewState) {
 
 @property (nonatomic, assign) CGFloat additionalBottomOffsetForInfinityScrollTrigger;
 
+@property (nonatomic, assign) BOOL callInfiniteScrollActionImmediatly;
+
 - (instancetype)initWithHeight:(CGFloat)height scrollView:(UIScrollView *)scrollView;
 
 - (void)beginInfiniteScrolling;

--- a/INSPullToRefresh/INSInfiniteScrollBackgroundView.m
+++ b/INSPullToRefresh/INSInfiniteScrollBackgroundView.m
@@ -251,8 +251,15 @@ static CGFloat const INSInfinityScrollContentInsetAnimationTime = 0.3;
         }
     }];
 
-    // This will delay handler execution until scroll deceleration
-    [self performSelector:@selector(callInfiniteScrollActionHandler) withObject:self afterDelay:0.1 inModes:@[ NSDefaultRunLoopMode ]];
+    
+    // Whether should the handler execution be delayed until scroll deceleration or not
+    
+    if( _callInfiniteScrollActionImmediatly ) {
+        [self callInfiniteScrollActionHandler];
+    }
+    else {
+        [self performSelector:@selector(callInfiniteScrollActionHandler) withObject:self afterDelay:0.1 inModes:@[ NSDefaultRunLoopMode ]];
+    }
 }
 
 - (void)stopInfiniteScrollWithStoppingContentOffset:(BOOL)stopContentOffset {


### PR DESCRIPTION
Adds the property which indicates should the infinite scroll action be called immediately or with a delay.
For example, when you want to load the next contents smoothly before getting to the end of the list, the infinite scroll action should be called immediately.