### PR TITLE
fix typo in callInfiniteScrollActionImmediately

### DIFF
--- a/INSPullToRefresh/INSInfiniteScrollBackgroundView.h
+++ b/INSPullToRefresh/INSInfiniteScrollBackgroundView.h
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSUInteger, INSInfiniteScrollBackgroundViewState) {
 
 @property (nonatomic, assign) CGFloat additionalBottomOffsetForInfinityScrollTrigger;
 
-@property (nonatomic, assign) BOOL callInfiniteScrollActionImmediatly;
+@property (nonatomic, assign) BOOL callInfiniteScrollActionImmediately;
 
 - (instancetype)initWithHeight:(CGFloat)height scrollView:(UIScrollView *)scrollView;
 

--- a/INSPullToRefresh/INSInfiniteScrollBackgroundView.m
+++ b/INSPullToRefresh/INSInfiniteScrollBackgroundView.m
@@ -258,7 +258,7 @@ static CGFloat const INSInfinityScrollContentInsetAnimationTime = 0.3;
     
     // Whether should the handler execution be delayed until scroll deceleration or not
     
-    if( _callInfiniteScrollActionImmediatly ) {
+    if( _callInfiniteScrollActionImmediately ) {
         [self callInfiniteScrollActionHandler];
     }
     else {


### PR DESCRIPTION
I figure it's best to fix it now in a breaking way rather than deprecate it and junk up the header.